### PR TITLE
Add autoplay image carousel 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import Carousel from "./components/Carousel";
+
 import "./styles.css";
 
 export default function App(): JSX.Element {
@@ -11,6 +13,23 @@ export default function App(): JSX.Element {
         <li>Each image slide will auto-page after 7 seconds</li>
         <li>Each video slide will auto-page after video finishes playing</li>
       </ul>
+
+      <Carousel
+        slides={[
+          {
+            src: "https://placekitten.com/320/240",
+          },
+          {
+            src: "https://placekitten.com/321/240",
+          },
+          {
+            src: "https://placekitten.com/322/240",
+          },
+          {
+            src: "https://placekitten.com/323/240",
+          },
+        ]}
+      />
     </div>
   );
 }

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -1,0 +1,62 @@
+import React, { useState, useEffect } from "react";
+
+import { useTimer } from "../hooks/useTimer";
+
+import { formatTime } from "../utils";
+
+export interface Slide {
+  src: string;
+}
+
+interface Props {
+  slides: Slide[];
+  slideDuration?: number;
+}
+
+const Carousel = ({ slides, slideDuration = 7000 }: Props): JSX.Element => {
+  const [activeSlide, setActiveSlide] = useState(0);
+  const duration = slideDuration;
+  const { pause, reset, start, time } = useTimer(duration);
+
+  /* Change slide after slide duration */
+  useEffect(() => {
+    if (time >= duration) {
+      setActiveSlide((activeSlide + 1) % slides.length);
+      reset();
+    }
+  }, [activeSlide, duration, slides, reset, time]);
+
+  /* Reset states after slide changes */
+  useEffect(() => {
+    start();
+  }, [activeSlide, reset, start]);
+
+  /* Init carousel */
+  useEffect(() => {
+    start();
+    return () => pause();
+  }, [start, pause]);
+
+  return (
+    <>
+      <div>Slide duration = {formatTime(duration)}s</div>
+      <div>Elapsed slide time = {formatTime(time)}s</div>
+      <div>{`Slide progress = ${Math.ceil((time / duration) * 100)}%`}</div>
+      <div>
+        {slides.map(({ src }, index) => {
+          return (
+            <div
+              key={index}
+              style={{ display: activeSlide === index ? "block" : "none" }} // "carousel"
+            >
+              <img src={src} alt={""} />
+            </div>
+          );
+        })}
+      </div>
+      <div>{`Slide ${activeSlide + 1} of ${slides.length}`}</div>
+    </>
+  );
+};
+
+export default Carousel;

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 
 import { useTimer } from "../hooks/useTimer";
 
-import { formatTime, getPercentage } from "../utils";
+import { getSeconds, getPercentage } from "../utils";
 
 export interface Slide {
   src: string;
@@ -39,8 +39,8 @@ const Carousel = ({ slides, slideDuration = 7000 }: Props): JSX.Element => {
 
   return (
     <>
-      <div>Slide duration = {formatTime(duration)}s</div>
-      <div>Elapsed slide time = {formatTime(time)}s</div>
+      <div>Slide duration = {getSeconds(duration)}s</div>
+      <div>Elapsed slide time = {getSeconds(time)}s</div>
       <div>{`Slide progress = ${getPercentage(time, duration)}%`}</div>
       <div>
         {slides.map(({ src }, index) => {

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 
 import { useTimer } from "../hooks/useTimer";
 
-import { formatTime } from "../utils";
+import { formatTime, getPercentage } from "../utils";
 
 export interface Slide {
   src: string;
@@ -41,7 +41,7 @@ const Carousel = ({ slides, slideDuration = 7000 }: Props): JSX.Element => {
     <>
       <div>Slide duration = {formatTime(duration)}s</div>
       <div>Elapsed slide time = {formatTime(time)}s</div>
-      <div>{`Slide progress = ${Math.ceil((time / duration) * 100)}%`}</div>
+      <div>{`Slide progress = ${getPercentage(time, duration)}%`}</div>
       <div>
         {slides.map(({ src }, index) => {
           return (

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+interface Timer {
+  pause: () => void;
+  reset: () => void;
+  start: () => void;
+  time: number;
+}
+
+export const useTimer = (duration: number): Timer => {
+  const [time, setTime] = useState(0);
+  const timer = useRef<NodeJS.Timeout | null>(null);
+
+  const start = useCallback(() => {
+    if (!timer.current) {
+      timer.current = setInterval(() => setTime((state) => state + 100), 100);
+    }
+  }, []);
+
+  const pause = useCallback(() => {
+    if (timer.current) {
+      clearInterval(timer.current);
+      timer.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    setTime(0);
+  }, []);
+
+  useEffect(() => {
+    if (time >= duration) {
+      pause();
+    }
+  }, [time, duration, pause]);
+
+  return { pause, reset, start, time };
+};

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -1,0 +1,3 @@
+export const formatTime = (milliseconds: number): number => {
+  return Math.ceil(milliseconds / 1000);
+};

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -1,3 +1,7 @@
 export const formatTime = (milliseconds: number): number => {
   return Math.ceil(milliseconds / 1000);
 };
+
+export const getPercentage = (time: number, duration: number): number => {
+  return Math.ceil((time / duration) * 100);
+};

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -1,4 +1,4 @@
-export const formatTime = (milliseconds: number): number => {
+export const getSeconds = (milliseconds: number): number => {
   return Math.ceil(milliseconds / 1000);
 };
 


### PR DESCRIPTION
This PR adds an image carousel that autorotates between slides, displaying each for seven seconds.

The timing magic here happens in `useTimer`, which uses a `setInterval` to deliver time updates in 100ms increments. It allows the consuming component control to `start`, `pause`, and `reset` the timer. It also accepts a duration parameter so that the length of the timer can vary.

The way our `Carousel` component uses this hook is that each new slide will `start` the timer. When we have reached the set duration for a slide, we update the `activeSlide` index and reset the timer. When the next slider loads, it then starts the timer anew.

## Testing instructions

Run in browser, you should see:
- Carousel that immediately starts auto-rotating
- 4 images of kittens, each one being displayed for seven seconds

## Notes

![autoplay-image-carousel](https://user-images.githubusercontent.com/1480505/82763421-90228e00-9dd5-11ea-9ac2-f94369e5267f.gif)
