### PR TITLE
Add video slides to carousel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ export default function App(): JSX.Element {
           },
           {
             src:
-              "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4",
+              "https://static.videezy.com/system/resources/previews/000/035/284/original/MVI_4230.mp4",
             type: "video/mp4",
           },
           {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,15 +18,20 @@ export default function App(): JSX.Element {
         slides={[
           {
             src: "https://placekitten.com/320/240",
+            type: "image/jpg",
           },
           {
-            src: "https://placekitten.com/321/240",
+            src:
+              "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4",
+            type: "video/mp4",
           },
           {
-            src: "https://placekitten.com/322/240",
+            src: "https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4",
+            type: "video/mp4",
           },
           {
-            src: "https://placekitten.com/323/240",
+            src: "https://vjs.zencdn.net/v/oceans.mp4",
+            type: "video/mp4",
           },
         ]}
       />

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -107,7 +107,7 @@ const Carousel = ({ slides, slideDuration = 7000 }: Props): JSX.Element => {
               key={index}
               style={{ display: activeSlide === index ? "block" : "none" }} // "carousel"
             >
-              {type.includes("video") ? (
+              {isVideoSlide(index) ? (
                 <Video
                   src={src}
                   type={type}

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -66,8 +66,10 @@ const Carousel = ({ slides, slideDuration = 7000 }: Props): JSX.Element => {
       if (newDuration !== 0) {
         setDuration(newDuration);
       }
+    } else {
+      setDuration(slideDuration);
     }
-  }, [activeSlide]);
+  }, [activeSlide, slideDuration]);
 
   /**
    * Let's focus on these three callbacks

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -1,4 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
+
+import Video from "./Video";
 
 import { useTimer } from "../hooks/useTimer";
 
@@ -6,6 +8,7 @@ import { getSeconds, getPercentage } from "../utils";
 
 export interface Slide {
   src: string;
+  type: string;
 }
 
 interface Props {
@@ -15,19 +18,32 @@ interface Props {
 
 const Carousel = ({ slides, slideDuration = 7000 }: Props): JSX.Element => {
   const [activeSlide, setActiveSlide] = useState(0);
-  const duration = slideDuration;
+  const [duration, setDuration] = useState(slideDuration);
+  const [currentVideoTime, setCurrentVideoTime] = useState(0);
+  const videoDurationRefs = useRef<number[]>([]);
+
   const { pause, reset, start, time } = useTimer(duration);
+
+  const isVideoSlide = useCallback(
+    (index: number): boolean => {
+      return slides[index].type.includes("video");
+    },
+    [slides],
+  );
 
   /* Change slide after slide duration */
   useEffect(() => {
-    if (time >= duration) {
+    // If we are currently on a video slide,
+    // only a video end event will trigger a slide change
+    if (!isVideoSlide(activeSlide) && time >= duration) {
       setActiveSlide((activeSlide + 1) % slides.length);
       reset();
     }
-  }, [activeSlide, duration, slides, reset, time]);
+  }, [activeSlide, duration, isVideoSlide, slides, reset, time]);
 
   /* Reset states after slide changes */
   useEffect(() => {
+    setCurrentVideoTime(0);
     start();
   }, [activeSlide, reset, start]);
 
@@ -37,19 +53,75 @@ const Carousel = ({ slides, slideDuration = 7000 }: Props): JSX.Element => {
     return () => pause();
   }, [start, pause]);
 
+  /**
+   * If we are on a video slide, set the video's duration
+   * to be the slide duration
+   */
+  useEffect(() => {
+    if (
+      videoDurationRefs.current.length &&
+      videoDurationRefs.current[activeSlide]
+    ) {
+      const newDuration = videoDurationRefs.current[activeSlide];
+      if (newDuration !== 0) {
+        setDuration(newDuration);
+      }
+    }
+  }, [activeSlide]);
+
+  /**
+   * Let's focus on these three callbacks
+   */
+  /* Get video durations after load */
+  const handleVideoLoad = (duration: number, index: number) => {
+    videoDurationRefs.current[index] = duration;
+    if (index === 0) {
+      setDuration(duration);
+    }
+  };
+
+  /* Update current video time */
+  const handleVideoUpdate = (currentTime: number) => {
+    setCurrentVideoTime(currentTime);
+  };
+
+  /* Page to the next slide on video end */
+  const handleVideoEnd = () => {
+    setActiveSlide((activeSlide + 1) % slides.length);
+    reset();
+  };
+
   return (
     <>
       <div>Slide duration = {getSeconds(duration)}s</div>
       <div>Elapsed slide time = {getSeconds(time)}s</div>
-      <div>{`Slide progress = ${getPercentage(time, duration)}%`}</div>
       <div>
-        {slides.map(({ src }, index) => {
+        {isVideoSlide(activeSlide)
+          ? `Slide progress = ${getPercentage(currentVideoTime, duration)}%`
+          : `Slide progress = ${getPercentage(time, duration)}%`}
+      </div>
+      <div>
+        {slides.map(({ src, type }, index) => {
           return (
             <div
               key={index}
               style={{ display: activeSlide === index ? "block" : "none" }} // "carousel"
             >
-              <img src={src} alt={""} />
+              {type.includes("video") ? (
+                <Video
+                  src={src}
+                  type={type}
+                  activeIndex={activeSlide}
+                  index={index}
+                  onLoadVideoCallback={(duration) => {
+                    handleVideoLoad(duration, index);
+                  }}
+                  onUpdateVideoCallback={handleVideoUpdate}
+                  onEndedVideoCallback={handleVideoEnd}
+                />
+              ) : (
+                <img src={src} alt={""} />
+              )}
             </div>
           );
         })}

--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect, useRef } from "react";
+
+interface Props {
+  src: string;
+  type: string;
+  activeIndex: number;
+  index: number;
+  onLoadVideoCallback?: (duration: number) => void;
+  onUpdateVideoCallback?: (currentTime: number) => void;
+  onEndedVideoCallback?: () => void;
+}
+
+const Video = ({
+  src,
+  type,
+  activeIndex,
+  index,
+  onLoadVideoCallback,
+  onUpdateVideoCallback,
+  onEndedVideoCallback,
+}: Props): JSX.Element => {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const playVideo = () => {
+      if (videoRef.current) {
+        Promise.resolve(videoRef.current.play())
+          .then(() => {
+            console.log(`Playing ${index}. Active index is ${activeIndex}`);
+          })
+          .catch((error) => {
+            console.log(`Play Rejected: ${error.message}`);
+          });
+      }
+    };
+
+    if (isLoaded && index === activeIndex) {
+      playVideo();
+    }
+  }, [activeIndex, index, isLoaded]);
+
+  const onLoad = (video: HTMLVideoElement) => {
+    const duration = video.duration;
+    setIsLoaded(true);
+    console.log("Event: load", { duration });
+    onLoadVideoCallback && onLoadVideoCallback(duration * 1000);
+  };
+
+  const onUpdate = () => {
+    videoRef.current &&
+      onUpdateVideoCallback &&
+      onUpdateVideoCallback(videoRef.current.currentTime * 1000);
+  };
+
+  const onEnded = () => {
+    onEndedVideoCallback && onEndedVideoCallback();
+  };
+
+  return (
+    <video
+      ref={videoRef}
+      width="320"
+      height="240"
+      controls
+      muted
+      onLoadedMetadata={(event) => {
+        onLoad(event.target as HTMLVideoElement); // TODO
+      }}
+      onTimeUpdate={onUpdate}
+      onEnded={onEnded}
+    >
+      <source src={src} type={type} />
+      Your browser does not support the video tag.
+    </video>
+  );
+};
+
+export default Video;


### PR DESCRIPTION
This PR adds the ability for the carousel to display video slides by adding the `Video` component and some new timer logic to `Carousel`. When a video slide appears, it will remain the active slide until the video finishes playing, at which point the carousel will move to the next slide. This is achieved with three callback functions that are passed to `Video`:

- `handleVideoLoad` - In order to display the "percent complete" of the current slide, `Carousel` needs to know the duration of each video slide, which we can only report after each video's metadata has loaded.
- `handleVideoUpdate` - Again, in order to display the "percent complete" of the current slide, `Carousel` needs to know the video's current time as it plays.
- `handleVideoEnd` - To be safe, we wait until the video reports that it has finished playing to move to the next slide.

`Video` contains a lot of video-specific code for facilitating the above callbacks, but at a high-level all it does is load and play the video.

## Testing instructions

- Load the side, you should see the same image slide from the previous PR
- The second slide that appears will be a video 

## Notes
* Make sure that your browser or ad blockers are not blocking video autoplay

![autoplay-video-carousel](https://user-images.githubusercontent.com/1480505/82764881-47240700-9de0-11ea-9956-4440a4ee37ff.gif)
