### PR TITLE
chore: rename Carousel to AutoplayCarousel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import Carousel from "./components/Carousel";
+import AutoplayCarousel from "./components/AutoplayCarousel";
 
 import "./styles.css";
 
@@ -14,7 +14,7 @@ export default function App(): JSX.Element {
         <li>Each video slide will auto-page after video finishes playing</li>
       </ul>
 
-      <Carousel
+      <AutoplayCarousel
         slides={[
           {
             src: "https://placekitten.com/320/240",

--- a/src/components/AutoplayCarousel.tsx
+++ b/src/components/AutoplayCarousel.tsx
@@ -16,7 +16,10 @@ interface Props {
   slideDuration?: number;
 }
 
-const Carousel = ({ slides, slideDuration = 7000 }: Props): JSX.Element => {
+const AutoplayCarousel = ({
+  slides,
+  slideDuration = 7000,
+}: Props): JSX.Element => {
   const [activeSlide, setActiveSlide] = useState(0);
   const [duration, setDuration] = useState(slideDuration);
   const [currentVideoTime, setCurrentVideoTime] = useState(0);
@@ -133,4 +136,4 @@ const Carousel = ({ slides, slideDuration = 7000 }: Props): JSX.Element => {
   );
 };
 
-export default Carousel;
+export default AutoplayCarousel;


### PR DESCRIPTION
This PR renames the `Carousel` component to `AutoplayCarousel` for clarity and consistency with the repo name.

