### PR TITLE
wrap video event handlers in useCallback

### DIFF
--- a/src/components/AutoplayCarousel.tsx
+++ b/src/components/AutoplayCarousel.tsx
@@ -79,23 +79,23 @@ const AutoplayCarousel = ({
    * Let's focus on these three callbacks
    */
   /* Get video durations after load */
-  const handleVideoLoad = (duration: number, index: number) => {
+  const handleVideoLoad = useCallback((duration: number, index: number) => {
     videoDurationRefs.current[index] = duration;
     if (index === 0) {
       setDuration(duration);
     }
-  };
+  }, []);
 
   /* Update current video time */
-  const handleVideoUpdate = (currentTime: number) => {
+  const handleVideoUpdate = useCallback((currentTime: number) => {
     setCurrentVideoTime(currentTime);
-  };
+  }, []);
 
   /* Page to the next slide on video end */
-  const handleVideoEnd = () => {
+  const handleVideoEnd = useCallback(() => {
     setActiveSlide((activeSlide + 1) % slides.length);
     reset();
-  };
+  }, [activeSlide, reset, slides.length]);
 
   return (
     <>


### PR DESCRIPTION
This PR wraps the video event callbacks that we pass to `VideoSlide` in `useCallback` in an attempt to prevent those props from changing on each render.
