### PR TITLE
useReducer w/ useCallback

### DIFF
--- a/src/components/AutoplayCarousel.tsx
+++ b/src/components/AutoplayCarousel.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  useReducer,
+} from "react";
 
 import ImageSlide from "./ImageSlide";
 import VideoSlide from "./VideoSlide";
@@ -17,10 +23,54 @@ interface Props {
   slideDuration?: number;
 }
 
+export enum ActionType {
+  VIDEO_LOAD = "VIDEO_LOAD",
+}
+
+interface StateProps {
+  slideDurations: number[];
+}
+
+interface VideoLoadPayload {
+  duration?: number;
+  index?: number;
+}
+
+interface ActionProps {
+  type: ActionType;
+  payload?: VideoLoadPayload;
+}
+
+export const initialState = { slideDurations: [] };
+
+const carouselReducer = (state: StateProps, action: ActionProps) => {
+  const { index, duration } = action.payload || {};
+
+  switch (action.type) {
+    case ActionType.VIDEO_LOAD: {
+      if ((!!index || index === 0) && !!duration) {
+        const slideDurations = [...state.slideDurations];
+        slideDurations[index] = duration;
+
+        return {
+          ...state,
+          slideDurations,
+        };
+      }
+    }
+    default: {
+      console.log("featuredCarouselReducer", `${action.type} not found`);
+      return state;
+    }
+  }
+};
+
 const AutoplayCarousel = ({
   slides,
   slideDuration = 7000,
 }: Props): JSX.Element => {
+  const [state, dispatch] = useReducer(carouselReducer, initialState);
+  const { slideDurations } = state;
   const [activeSlide, setActiveSlide] = useState(0);
   const [duration, setDuration] = useState(slideDuration);
   const [currentVideoTime, setCurrentVideoTime] = useState(0);
@@ -79,12 +129,18 @@ const AutoplayCarousel = ({
    * Let's focus on these three callbacks
    */
   /* Get video durations after load */
-  const handleVideoLoad = useCallback((duration: number, index: number) => {
-    videoDurationRefs.current[index] = duration;
-    if (index === 0) {
-      setDuration(duration);
-    }
-  }, []);
+  useEffect(() => {
+    slideDurations.forEach((item: number, index: number) => {
+      videoDurationRefs.current[index] = item;
+      if (index === 0) {
+        setDuration(duration);
+      }
+    });
+  }, [slideDurations, slideDurations.length, duration]);
+
+  const handleVideoLoad = (duration: number, index: number) => {
+    dispatch({ type: ActionType.VIDEO_LOAD, payload: { duration, index } });
+  };
 
   /* Update current video time */
   const handleVideoUpdate = useCallback((currentTime: number) => {

--- a/src/components/AutoplayCarousel.tsx
+++ b/src/components/AutoplayCarousel.tsx
@@ -38,13 +38,13 @@ interface VideoLoadPayload {
 
 interface ActionProps {
   type: ActionType;
-  payload?: VideoLoadPayload;
+  payload: VideoLoadPayload;
 }
 
 export const initialState = { slideDurations: [] };
 
 const carouselReducer = (state: StateProps, action: ActionProps) => {
-  const { index, duration } = action.payload || {};
+  const { index, duration } = action.payload;
 
   switch (action.type) {
     case ActionType.VIDEO_LOAD: {
@@ -138,9 +138,9 @@ const AutoplayCarousel = ({
     });
   }, [slideDurations, slideDurations.length, duration]);
 
-  const handleVideoLoad = (duration: number, index: number) => {
+  const handleVideoLoad = useCallback((duration: number, index: number) => {
     dispatch({ type: ActionType.VIDEO_LOAD, payload: { duration, index } });
-  };
+  }, []);
 
   /* Update current video time */
   const handleVideoUpdate = useCallback((currentTime: number) => {
@@ -175,9 +175,7 @@ const AutoplayCarousel = ({
                   type={type}
                   activeIndex={activeSlide}
                   index={index}
-                  onLoadVideoCallback={(duration) => {
-                    handleVideoLoad(duration, index);
-                  }}
+                  onLoadVideoCallback={handleVideoLoad}
                   onUpdateVideoCallback={handleVideoUpdate}
                   onEndedVideoCallback={handleVideoEnd}
                 />

--- a/src/components/VideoSlide.tsx
+++ b/src/components/VideoSlide.tsx
@@ -5,7 +5,7 @@ interface Props {
   type: string;
   activeIndex: number;
   index: number;
-  onLoadVideoCallback?: (duration: number) => void;
+  onLoadVideoCallback?: (duration: number, index: number) => void;
   onUpdateVideoCallback?: (currentTime: number) => void;
   onEndedVideoCallback?: () => void;
 }
@@ -44,7 +44,7 @@ const Video = ({
     const duration = video.duration;
     setIsLoaded(true);
     console.log("Event: load", { duration });
-    onLoadVideoCallback && onLoadVideoCallback(duration * 1000);
+    onLoadVideoCallback && onLoadVideoCallback(duration * 1000, index);
   };
 
   const onUpdate = () => {


### PR DESCRIPTION
Issue:
- `onLoadVideoCallback` is constantly changing on each tick of `useTimer` which causes `autoplayCarousel` to re-render
- Avoid passing dispatch as a prop to `VideoSlide` so that `autoplayCarousel` can manage it’s internal state

Solution:
- Add `useReducer` which passes down `dispatch` and it will reduces the `autoplayCarousel` re-renders.
- Wrap `handleVideoLoad` callback with `useCallback` 