### PR TITLE
memoize VideoSlide (prop invalidation example)

### DIFF
--- a/src/components/VideoSlide.tsx
+++ b/src/components/VideoSlide.tsx
@@ -76,4 +76,4 @@ const Video = ({
   );
 };
 
-export default Video;
+export default React.memo(Video);


### PR DESCRIPTION
This PR add `React.memo` to `VideoSlide`, which is ultimately not effective since it receives an updated prop value on each timer tick.


